### PR TITLE
Add recipe favorites table

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ DB_PASSWORD=your_password
 DB_NAME=your_database
 REDIS_HOST=localhost
 REDIS_PORT=6379
+DEEPSEEK_API_KEY=your_deepseek_key
+# Alternatively, specify DEEPSEEK_API_KEY_FILE with a path to the key file
 ```
 
 3. Run the application:
@@ -73,6 +75,10 @@ The API documentation is generated using Swagger/OpenAPI. To view the documentat
 
 - `q` - search term matched against recipe name and description
 - `category` - filter by category
+- `POST /api/v1/recipes/:id/favorite` - add a recipe to the authenticated user's favorites
+- `DELETE /api/v1/recipes/:id/favorite` - remove a recipe from the authenticated user's favorites
+
+Favorites are stored in the `recipe_favorites` table created by the database migrations.
 
 ### LLM Endpoint
 

--- a/internal/api/llm_test.go
+++ b/internal/api/llm_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -47,17 +46,7 @@ func setupLLMDB(t *testing.T) *gorm.DB {
 func TestQuerySavesRecipe(t *testing.T) {
 	db := setupLLMDB(t)
 
-	tmpFile, err := os.CreateTemp(t.TempDir(), "key")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
-	if _, err := tmpFile.WriteString("dummy"); err != nil {
-		t.Fatalf("failed to write key: %v", err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		t.Fatalf("failed to close temp file: %v", err)
-	}
-	t.Setenv("DEEPSEEK_API_KEY_FILE", tmpFile.Name())
+	t.Setenv("DEEPSEEK_API_KEY", "dummy")
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -124,17 +113,7 @@ func TestQuerySavesRecipe(t *testing.T) {
 func TestQueryUnauthorized(t *testing.T) {
 	db := setupLLMDB(t)
 
-	tmpFile, err := os.CreateTemp(t.TempDir(), "key")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
-	if _, err := tmpFile.WriteString("dummy"); err != nil {
-		t.Fatalf("failed to write key: %v", err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		t.Fatalf("failed to close temp file: %v", err)
-	}
-	t.Setenv("DEEPSEEK_API_KEY_FILE", tmpFile.Name())
+	t.Setenv("DEEPSEEK_API_KEY", "dummy")
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -19,19 +19,22 @@ type LLMService struct {
 
 // NewLLMService creates a new LLMService instance
 func NewLLMService() (*LLMService, error) {
-	apiKeyFile := os.Getenv("DEEPSEEK_API_KEY_FILE")
-	if apiKeyFile == "" {
-		return nil, fmt.Errorf("DEEPSEEK_API_KEY_FILE environment variable not set")
-	}
-
-	apiKeyBytes, err := os.ReadFile(apiKeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read API key file: %w", err)
-	}
-
-	apiKey := strings.TrimSpace(string(apiKeyBytes))
+	apiKey := os.Getenv("DEEPSEEK_API_KEY")
 	if apiKey == "" {
-		return nil, fmt.Errorf("API key file is empty")
+		apiKeyFile := os.Getenv("DEEPSEEK_API_KEY_FILE")
+		if apiKeyFile == "" {
+			return nil, fmt.Errorf("DEEPSEEK_API_KEY or DEEPSEEK_API_KEY_FILE must be set")
+		}
+
+		apiKeyBytes, err := os.ReadFile(apiKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read API key file: %w", err)
+		}
+
+		apiKey = strings.TrimSpace(string(apiKeyBytes))
+		if apiKey == "" {
+			return nil, fmt.Errorf("API key file is empty")
+		}
 	}
 
 	apiURL := os.Getenv("DEEPSEEK_API_URL")

--- a/migrations/0006_create_recipe_favorites.sql
+++ b/migrations/0006_create_recipe_favorites.sql
@@ -1,0 +1,23 @@
+-- Create recipe_favorites table
+CREATE TABLE recipe_favorites (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    recipe_id UUID NOT NULL REFERENCES recipes(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT recipe_favorites_unique UNIQUE (recipe_id, user_id)
+);
+
+-- Create indexes
+CREATE INDEX idx_recipe_favorites_recipe_id ON recipe_favorites(recipe_id);
+CREATE INDEX idx_recipe_favorites_user_id ON recipe_favorites(user_id);
+
+-- Create trigger for updated_at
+CREATE TRIGGER update_recipe_favorites_updated_at
+    BEFORE UPDATE ON recipe_favorites
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Add comment
+COMMENT ON TABLE recipe_favorites IS 'Stores user recipe favorites';
+


### PR DESCRIPTION
## Summary
- add migration for `recipe_favorites` table
- document favorite/unfavorite endpoints
- run migrations in dev
- read `DEEPSEEK_API_KEY` directly in `LLMService` with fallback to `_FILE`
- update tests and README for new env var

## Testing
- `go test ./...`
- `go run ./cmd/api` *(fails to connect to database, but env var check works)*

------
https://chatgpt.com/codex/tasks/task_e_6840bcdb11ec832fa5ea124cf2087f15