### PR TITLE
Create profile records on user registration

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/pageza/alchemorsel-v2/backend/internal/service"
@@ -18,12 +19,12 @@ func NewAuthHandler(authService *service.AuthService) *AuthHandler {
 }
 
 type RegisterRequest struct {
-	Name     string `json:"name" binding:"required"`
-	Email    string `json:"email" binding:"required,email"`
-	Password string `json:"password" binding:"required,min=6"`
-	Username string `json:"username" binding:"required"`
-	DietaryPreferences string `json:"dietary_preferences"`
-	Allergies string `json:"allergies"`
+	Name               string   `json:"name" binding:"required"`
+	Email              string   `json:"email" binding:"required,email"`
+	Password           string   `json:"password" binding:"required,min=6"`
+	Username           string   `json:"username" binding:"required"`
+	DietaryPreferences []string `json:"dietary_preferences"`
+	Allergies          []string `json:"allergies"`
 }
 
 type LoginRequest struct {
@@ -38,7 +39,9 @@ func (h *AuthHandler) Register(c *gin.Context) {
 		return
 	}
 
-	token, err := h.authService.Register(req.Name, req.Email, req.Password)
+	dietary := strings.Join(req.DietaryPreferences, ",")
+	allergies := strings.Join(req.Allergies, ",")
+	token, err := h.authService.Register(req.Name, req.Email, req.Password, req.Username, dietary, allergies)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/models/dietary.go
+++ b/internal/models/dietary.go
@@ -1,0 +1,38 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// DietaryPreference represents a user's dietary preference entry.
+type DietaryPreference struct {
+	ID             uuid.UUID      `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	UserID         uuid.UUID      `gorm:"type:uuid;not null;index" json:"user_id"`
+	PreferenceType string         `gorm:"type:dietary_preference_type;not null" json:"preference_type"`
+	CustomName     string         `gorm:"size:50" json:"custom_name"`
+	CreatedAt      time.Time      `json:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at"`
+	DeletedAt      gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+func (DietaryPreference) TableName() string {
+	return "dietary_preferences"
+}
+
+// Allergen represents an allergen entry for a user.
+type Allergen struct {
+	ID            uuid.UUID      `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	UserID        uuid.UUID      `gorm:"type:uuid;not null;index" json:"user_id"`
+	AllergenName  string         `gorm:"size:50;not null" json:"allergen_name"`
+	SeverityLevel int            `gorm:"not null" json:"severity_level"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
+}
+
+func (Allergen) TableName() string {
+	return "allergens"
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -21,6 +21,7 @@ type UserProfile struct {
 	ID                uuid.UUID      `gorm:"type:uuid;primarykey;default:gen_random_uuid()" json:"id"`
 	UserID            uuid.UUID      `gorm:"type:uuid;not null;uniqueIndex" json:"user_id"`
 	Username          string         `gorm:"size:50;not null;uniqueIndex" json:"username"`
+	Email             string         `gorm:"size:255;not null" json:"email"`
 	Bio               string         `gorm:"type:text" json:"bio"`
 	ProfilePictureURL string         `gorm:"size:255" json:"profile_picture_url"`
 	PrivacyLevel      string         `gorm:"type:privacy_level;not null;default:'private'" json:"privacy_level"`


### PR DESCRIPTION
## Summary
- extend `RegisterRequest` to accept a username, dietary preferences, and allergy data
- create a `DietaryPreference` and `Allergen` model
- ensure `UserProfile` stores email
- insert related profile, dietary preference, and allergen records when registering

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684124cec844832fbd6126c448ea405c