### PR TITLE
Add dietary preferences to recipe workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ It also returns a JWT token on success.
 
 - `q` - search term. When running with Postgres, this uses pgvector to order results by embedding similarity.
 - `category` - filter by category
+- `dietary` - comma-separated dietary preferences to match recipe categories
+- `exclude` - comma-separated allergens or ingredients to omit
 - `POST /api/v1/recipes/:id/favorite` - add a recipe to the authenticated user's favorites
 - `DELETE /api/v1/recipes/:id/favorite` - remove a recipe from the authenticated user's favorites
 
@@ -123,6 +125,8 @@ Favorites are stored in the `recipe_favorites` table created by the database mig
 `POST /api/v1/llm/query` generates a recipe using the language model. This route
 requires a valid `Authorization` header with a bearer token. The response
 includes the persisted recipe with the authenticated user ID attached.
+The generated recipe respects the user's saved dietary preferences and
+allergens.
 
 ## Contributing
 

--- a/internal/service/llm.go
+++ b/internal/service/llm.go
@@ -70,7 +70,15 @@ type Macros struct {
 }
 
 // GenerateRecipe generates a recipe using the DeepSeek API
-func (s *LLMService) GenerateRecipe(query string) (string, error) {
+func (s *LLMService) GenerateRecipe(query string, dietaryPrefs, allergens []string) (string, error) {
+	prompt := fmt.Sprintf("Generate a recipe for: %s", query)
+	if len(dietaryPrefs) > 0 {
+		prompt += ". The recipe should be suitable for: " + strings.Join(dietaryPrefs, ", ")
+	}
+	if len(allergens) > 0 {
+		prompt += ". Avoid using: " + strings.Join(allergens, ", ")
+	}
+
 	messages := []Message{
 		{
 			Role: "system",
@@ -100,7 +108,7 @@ func (s *LLMService) GenerateRecipe(query string) (string, error) {
 		},
 		{
 			Role:    "user",
-			Content: fmt.Sprintf("Generate a recipe for: %s", query),
+			Content: prompt,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- respect user dietary preferences and allergies when generating recipes
- add dietary and allergen filtering to recipe search
- document new filters and LLM behavior
- test dietary/allergen flow

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6841c609c82c832f862ca60f83d4f6f7